### PR TITLE
fix: MARKDOWN_ANCHOR_LINK_REGEXP issue

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -56,15 +56,20 @@ describe("isAnchorLinkInText", () => {
     ],
   );
 
-  /**
-   * @todo Check why 2nd example fails
-   */
   cases(
     "Should return true if link exists",
     (opts) => {
       expect(isAnchorLinkInText(opts.line)).toBeTruthy();
     },
-    [{ name: "# Header1[⬆️](#top)", line: "# Header1[⬆️](#top)" }],
+    [
+      { name: "# Header[⬆️](#top)", line: "# Header[⬆️](#top)" },
+      { name: "# Header [⬆️](#top)", line: "# Header [⬆️](#top)" },
+      {
+        name: "# Header with words[⬆️](#top)",
+        line: "# Header with words[⬆️](#top)",
+      },
+      { name: "#### Header [link](#link)", line: "#### Header [link](#link)" },
+    ],
   );
 });
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,7 @@
 export const ARROW_UP = "\u2B06";
 
 export const WHITE_SPASE_REGEXP = /\s/g;
-export const MARKDOWN_ANCHOR_LINK_REGEXP = /\[.+\]\(\#.+\)$/g;
+export const MARKDOWN_ANCHOR_LINK_REGEXP = /\[.+\]\(\#.+\)$/;
 export const MARKDOWN_ANY_LINK_REGEXP = /\[.+\]\(.+\)$/g;
 export const MARKDOWN_HEADER_REGEXP = /^\#{1,6}\s+/;
 export const SPICIAL_CHARS_REGEXP = /[\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,./:;<=>?@[\]^`{|}~’]/g;


### PR DESCRIPTION
## Description

Fix issue with global RegExp for MARKDOWN_ANCHOR_LINK_REGEXP.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
