### PR TITLE
fix: add comment for last link when position 'end'

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -109,7 +109,9 @@ export function createNewFileContent(
 
   let newFileContent = fileContentByLine.join("\n");
   if (!Number.isFinite(endHeaderIndex) && "end" === argv.position) {
-    newFileContent += `${LINK_OFFSET}[${linkText}](#${anchorSlug})\n`;
+    newFileContent += `${LINK_OFFSET}[${linkText}](#${anchorSlug})${
+      argv.silent ? "" : LINK_COMMENT
+    }\n`;
   }
 
   return newFileContent;


### PR DESCRIPTION
## Description

Added comment for the last link when position option is "end"

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
